### PR TITLE
Add home link to banner and remove website title

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,11 +1,12 @@
 <header class="site-header">
 
         <div class="wrapper">
-            <img src="/assets/bandeau.jpeg"></img>
+          <a class="site-title" rel="author" href="{{ "/" | relative_url }}">
+            <img src="/assets/bandeau.jpeg" alt="Bandeau d'illustration des Duchess France." />
+          </a>
           {%- assign default_paths = site.pages | map: "path" -%}
           {%- assign page_paths = site.header_pages | default: default_paths -%}
           {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
-          <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
       
           {%- if titles_size > 0 -%}
             <nav class="site-nav">

--- a/docs/_layout/home.html
+++ b/docs/_layout/home.html
@@ -4,7 +4,9 @@ layout: default
 
 <div class="home">
 
-<img src="assets/bandeau.jpeg"></img>
+  <a class="site-title" rel="author" href="{{ "/" | relative_url }}">
+    <img src="/assets/bandeau.jpeg" alt="Bandeau d'illustration des Duchess France." />
+  </a>
   {%- if page.title -%}
     <h1 class="page-heading">{{ page.title }}</h1>
   {%- endif -%}


### PR DESCRIPTION
Related to this issue => https://github.com/DuchessFrance/DuchessFrance.github.io/issues/10

- I remove website title
- I add link to main banner (in both templates, i don't know if they are both used)
- Adding `alt` attribut to `<img>` for an easy accessibility improvement :)