### PR TITLE
Faciliter l'installation du projet via docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,20 +69,26 @@ author: Angélique Jard
 - Installer `git`
 - Ouvrir le dossier docs `cd docs`
 
-### Lancer le site
-#### Via Docker
-- Installer `docker`
+### Lancer le site en local
+
+#### Via docker-compose
+- Installer `docker` et `docker-compose`
 - Lancer le site en utilisant la commande `docker-compose up`
+- Attendre jusqu'à voir dans la console: 
 
+```bash
+Server address: http://0.0.0.0:4000/
+```
 
-#### En local
+- Consulter le site sur http://127.0.0.1:4000/
+
+#### En jekyll natif
 - Installer jekyll en suivant la doc officielle https://jekyllrb.com/docs/pages/
 - Installer les gem avec la commande `bundle install` dans `docs`
-- Lancer le site en utilisant les commandes suivantes :
+- Et lancer le site en utilisant les commandes suivantes :
 ```
 cd docs
-jekyll build
-jekyll serve
+bundle exec jekyll serve
 ```
 
 ### Pour proposer un changement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,12 +62,28 @@ author: Angélique Jard
 
 7. Une fois la Pull Request revue, une des membres de la Core Team mergera la Pull Request et le post sera publié.
 
+
 ## Modifier le site
 
 ### Pre-requis
 - Installer `git`
+- Ouvrir le dossier docs `cd docs`
+
+### Lancer le site
+#### Via Docker
+- Installer `docker`
+- Lancer le site en utilisant la commande `docker-compose up`
+
+
+#### En local
 - Installer jekyll en suivant la doc officielle https://jekyllrb.com/docs/pages/
 - Installer les gem avec la commande `bundle install` dans `docs`
+- Lancer le site en utilisant les commandes suivantes :
+```
+cd docs
+jekyll build
+jekyll serve
+```
 
 ### Pour proposer un changement
 - Faire un fork du repo (via le bouton "fork" en haut à droite)
@@ -77,13 +93,9 @@ author: Angélique Jard
 git checkout -b mabranche
 ```
 - Effectuer les modifications
-- Tester le rendu en local en lançant les commandes jekyll depuis le répertoire "docs":
-```
-cd docs
-jekyll build
-jekyll serve
-```
+- Tester le rendu en local
 - Proposer une Pull Request
+
 
 ### Références
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Le blog Duchess est un site
 
 Si vous souhaitez contribuer au developpement du site:
 - [Contribuer](CONTRIBUTING.md)
+- [Le site en preview][https://duchessfrance.github.io/]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,5 @@ services:
       - 4000:4000
       - 35729:35729
     volumes:
-      - "$PWD:/srv/jekyll"
-      - "$PWD/vendor/bundle:/usr/local/bundle"
+      - "$PWD/docs:/srv/jekyll"
+      - "$PWD/docs/vendor/bundle:/usr/local/bundle"

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  web:
+    image: jekyll/jekyll
+    container_name: duchess_web
+    environment:
+      - JEKYLL_ENV=development
+    command: jekyll serve --livereload
+    ports:
+      - 4000:4000
+      - 35729:35729
+    volumes:
+      - "$PWD:/srv/jekyll"
+      - "$PWD/vendor/bundle:/usr/local/bundle"


### PR DESCRIPTION
#27 

Ajout d'un docker-compose pour pouvoir lancer le site et voir ses modifications en livereload sans avoir a installer l'écosystème Jekyll sur son poste de travail.
Cela corrigera en passant les problèmes d'incompatibilité du Gemfile.lock entre les différentes platforms.