### PR TITLE
Gitpod integration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,3 @@
-#ARG GITPOD_IMAGE=gitpod/workspace-base:latest
-#FROM ${GITPOD_IMAGE}
-
-# Install Jekyll
-#RUN sudo gem install jekyll bundler
-
 FROM gitpod/workspace-full:latest
 
 # Install Jekyll

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,13 +1,5 @@
 ARG GITPOD_IMAGE=gitpod/workspace-base:latest
 FROM ${GITPOD_IMAGE}
 
-## Install Ruby and pre-requisites
-
-RUN sudo apt-get install ruby-full build-essential zlib1g-dev
-
 # Install Jekyll
-#USER gitpod
-#RUN bash -lc "gem install jekyll"
-
-# Give back control
-#USER root
+RUN gem install jekyll bundler

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+ARG GITPOD_IMAGE=gitpod/workspace-base:latest
+FROM ${GITPOD_IMAGE}
+
+# Install Jekyll
+USER gitpod
+RUN bash -lc "gem install jekyll"
+
+# Give back control
+USER root

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,6 +1,10 @@
 ARG GITPOD_IMAGE=gitpod/workspace-base:latest
 FROM ${GITPOD_IMAGE}
 
+## Install Ruby and pre-requisites
+
+RUN sudo apt-get install ruby-full build-essential zlib1g-dev
+
 # Install Jekyll
 #USER gitpod
 #RUN bash -lc "gem install jekyll"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,4 +2,13 @@ ARG GITPOD_IMAGE=gitpod/workspace-base:latest
 FROM ${GITPOD_IMAGE}
 
 # Install Jekyll
-RUN gem install jekyll bundler
+RUN sudo gem install jekyll bundler
+
+#FROM gitpod/workspace-full:latest
+
+# Install Jekyll
+#USER gitpod
+#RUN bash -lc "gem install jekyll"
+
+# Give back control
+#USER root

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,8 +2,8 @@ ARG GITPOD_IMAGE=gitpod/workspace-base:latest
 FROM ${GITPOD_IMAGE}
 
 # Install Jekyll
-USER gitpod
-RUN bash -lc "gem install jekyll"
+#USER gitpod
+#RUN bash -lc "gem install jekyll"
 
 # Give back control
-USER root
+#USER root

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,14 +1,14 @@
-ARG GITPOD_IMAGE=gitpod/workspace-base:latest
-FROM ${GITPOD_IMAGE}
+#ARG GITPOD_IMAGE=gitpod/workspace-base:latest
+#FROM ${GITPOD_IMAGE}
 
 # Install Jekyll
-RUN sudo gem install jekyll bundler
+#RUN sudo gem install jekyll bundler
 
-#FROM gitpod/workspace-full:latest
+FROM gitpod/workspace-full:latest
 
 # Install Jekyll
-#USER gitpod
-#RUN bash -lc "gem install jekyll"
+USER gitpod
+RUN bash -lc "gem install jekyll"
 
 # Give back control
-#USER root
+USER root

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
-#image:
-#  file: .gitpod.Dockerfile
+image:
+  file: .gitpod.Dockerfile
 
 #tasks:
 #  - command: cd docs ; jekyll serve -l --host=0.0.0.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 image:
   file: .gitpod.Dockerfile
 
-#tasks:
-#  - command: cd docs ; jekyll serve -l --host=0.0.0.0
+tasks:
+  - init: bundle update && bundle install
+    command: jekyll serve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
-image:
-  file: .gitpod.Dockerfile
+#image:
+#  file: .gitpod.Dockerfile
 
-tasks:
-  - command: cd docs ; jekyll serve -l --host=0.0.0.0
+#tasks:
+#  - command: cd docs ; jekyll serve -l --host=0.0.0.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,5 +6,5 @@ ports:
     onOpen: open-browser
     
 tasks:
-  - init: bundle update && bundle install
+  - init: cd docs; bundle update && bundle install
     command: jekyll serve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,10 @@
 image:
   file: .gitpod.Dockerfile
 
+ports:
+  - port: 4000
+    onOpen: open-browser
+    
 tasks:
   - init: bundle update && bundle install
     command: jekyll serve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - command: cd docs ; jekyll serve -l --host=0.0.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuer au blog Duchess
 
-## Trying the blog
+## Contribuer au blog sans rien installer (gitpod)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Trying the blog
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io/tree/gitpod-integration)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 
 Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:4000`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 [![Ouvrir dans Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 
-Ouvrir GitPod, dans le terminal, suivre le lien avec un `ctrl + click` sur `http://localhost:4000`
+Ouvrir GitPod, dans le terminal, suivre le lien avec un `ctrl + click` (ou `command + click`) sur `http://localhost:4000`
 
 ## Ecrire un post dans le blog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contribuer au blog Duchess
 
-## Contribuer au blog sans rien installer (gitpod)
+## Contribuer au blog sans rien installer (GitPod)
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
+[![Ouvrir dans Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 
 Ouvrir GitPod, dans le terminal, suivre le lien avec un `ctrl + click` sur `http://localhost:4000`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Trying the blog
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io/tree/gitpod-integration)
 
 Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:8080`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io/tree/gitpod-integration)
 
-Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:8080`
+Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:4000`
 
 ## Ecrire un post dans le blog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Trying the blog
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/DuchessFrance/DuchessFrance.github.io.git)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 
 Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:8080`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DuchessFrance/DuchessFrance.github.io.git)
 
-Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:4000`
+Ouvrir GitPod, dans le terminal, suivre le lien avec un `ctrl + click` sur `http://localhost:4000`
 
 ## Ecrire un post dans le blog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contribuer au blog Duchess
 
+## Trying the blog
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/DuchessFrance/DuchessFrance.github.io.git)
+
+Open in GitPod and then, on the terminal, follow the link by doing `ctrl + click` on `http://localhost:8080`
+
 ## Ecrire un post dans le blog
 
 ### Pre-requis


### PR DESCRIPTION
Afin que cela soit plus simple de contribuer au blog, j'ai realisé l'integration avec GitPod.

J'ai rajouté un bouton 'open in gitpod" dans le fichier CONTRIBUTING.md.
Le lien redirige permet d'ouvrir un workspace GitPod avec le site (plus précisément la branche gitpod-integration pour tester cette PR) 

Au click sur le bouton Open in GitPod:
- La première fois, GitPod va builder l’image docker donc cela va prendre du temps (Jekyll est long a s’installer …)
- Ensuite il pull l’image
- Ensuite vous avez un VSCode qui tourne dans votre navigateur
- On exécute automatiquement les commandes qui permettent de se placer dans le fouler « docs/», on execute le bundle et on execute Jekyll serve
- Une pop-up avec le site devrait s’afficher (sous firefox il faut accepter d'ouvrir une popup)
- Et hop, on a le site qui tourne, et tout est dans le navigateur !