### PR TITLE
Multi auteurs : Et a la place de And

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -25,7 +25,7 @@ layout: default
             {% assign authordata = authordata | push: data %}
           {% endif %}
         {% endfor %}
-        <span class="post-meta">Par {{ authordata | array_to_sentence_string }}</span>
+        <span class="post-meta">Par {{ authordata | array_to_sentence_string: "et" }}</span>
 
 
 


### PR DESCRIPTION
#57 

<img width="601" alt="Capture d’écran 2022-04-02 à 01 32 46" src="https://user-images.githubusercontent.com/7658097/161354276-b61374e9-1ed9-48b3-9ccd-c07ca02077ed.png">

Changer le "And" en "Et" lorsqu'il y a plusieurs auteurs.