### PR TITLE
Proposition pour le changement de bloc dans la page contact

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -6,16 +6,16 @@ permalink: /contact/
 
 ## Vous pouvez nous SUIVRE sur:
 
-* [Instagram](https://www.instagram.com/duchessfr/)
-* [Twitter](http://twitter.com/duchessfr)
-* [Facebook](https://www.facebook.com/duchessfr)
-* [LinkedIn](https://www.linkedin.com/groups/2750811)
+- [Instagram](https://www.instagram.com/duchessfr/)
+- [Twitter](http://twitter.com/duchessfr)
+- [Facebook](https://www.facebook.com/duchessfr)
+- [LinkedIn](https://www.linkedin.com/groups/2750811)
 
 ## Pour être au coeur de l’association, échanger, débattre et partager:
 
-    Pour suivre et PARTICIPER à tous nos événements en France, rejoignez [Meetup](http://www.meetup.com/Duchess-France-Meetup/about/).
+Pour suivre et PARTICIPER à tous nos événements en France, rejoignez notre [Meetup Duchess France](http://www.meetup.com/Duchess-France-Meetup/about/).
 
-    Les offres d’emploi qui sont régulièrement proposées à notre communauté sont regroupées dans le channel slack #emploi
+Les offres d’emploi qui sont régulièrement proposées à notre communauté sont regroupées dans le channel slack #emploi
 
 ## Vous souhaitez contacter la Core Team Duchess:
 


### PR DESCRIPTION
#63 

![image](https://user-images.githubusercontent.com/7658097/161634398-70002e58-339a-4b26-ae97-577853825f33.png)

J'ai enlevé le bloc qui entourait le text, et changer la typo en "notre Meetup Duchess France".

En revanche sur la page du meetup duchess france, il y a une vidéo non disponible

![Capture d’écran 2022-04-04 à 23 23 28](https://user-images.githubusercontent.com/7658097/161634676-efa325a5-b8af-411d-b1f8-255a483836bb.png)

