### PR TITLE
Implémentation de la recherche

### DIFF
--- a/docs/_includes/search_bar.html
+++ b/docs/_includes/search_bar.html
@@ -1,0 +1,26 @@
+<!-- Based on plugin https://github.com/christian-fei/Simple-Jekyll-Search -->
+<!-- This includes a search bar that will filter according to what you put in the search.json -->
+<!-- @param {string} class - you can add 2 class -->
+<!-- search-bar--above - the content of autocomplete will go above -->
+<!-- search-bar--align-right - the content of autocomplete will be display at the right -->
+<!-- HTML elements for search -->
+<div class="search-bar {{include.class}}">
+  <input
+    type="text"
+    id="search-input"
+    class="search-input"
+    placeholder="Rechercher dans le blog.."
+  />
+  <ul id="results-container" class="results-container"></ul>
+</div>
+
+<!-- or without installing anything -->
+<script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js"></script>
+<!-- Configuration -->
+<script>
+  SimpleJekyllSearch({
+    searchInput: document.getElementById("search-input"),
+    resultsContainer: document.getElementById("results-container"),
+    json: "/search.json",
+  });
+</script>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -5,14 +5,15 @@ layout: default
   {%- if page.title -%}
     <h1 class="page-heading">{{ page.title }}</h1>
   {%- endif -%}
-
   {{ content }}
 
   {%- if paginator.posts.size > 0 -%}
-    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <section class="search">
+      <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+        {% include search_bar.html class="search-bar--above search-bar--align-right" %}
+    </section>
     <ul class="post-list">
       {%- for post in paginator.posts -%}
-
       <li>
         {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
         <span class="post-meta">{{ post.date | date: date_format }} </span>
@@ -48,11 +49,11 @@ layout: default
 <div class="pagination">
   {% if paginator.previous_page %}
     <a href="{{ paginator.previous_page_path }}" class="previous">
-      Posts précédents
+      <&nbsp;&nbsp;Posts précédents
     </a>
   {% endif %}
   {% if paginator.next_page %}
-    <a href="{{ paginator.next_page_path }}" class="next">Post Suivants</a>
+    <a href="{{ paginator.next_page_path }}" class="next">Posts Suivants&nbsp;&nbsp;></a>
   {% endif %}
 </div>
 

--- a/docs/_sass/_home.scss
+++ b/docs/_sass/_home.scss
@@ -1,3 +1,23 @@
 .pagination {
   text-align: center;
+
+  .previous {
+    margin-right: $spacing-unit / 3;
+  }
+}
+
+.search {
+  display: flex;
+  justify-content: space-between;
+}
+
+@include media-query($on-palm) {
+  .search {
+    display: block;
+    margin-bottom: $spacing-unit / 3;
+  }
+
+  .post-list-heading {
+    margin-bottom: 0;
+  }
 }

--- a/docs/_sass/_layout.scss
+++ b/docs/_sass/_layout.scss
@@ -1,6 +1,6 @@
 // Charte duchess
-$brand-primary: #e6223d;
-$brand-secondary: #1d1d1b;
+$brand-color-primary: #e6223d;
+$brand-color-secondary: #1d1d1b;
 $brand-font-primary: "Rene Bieder";
 $brand-font-secondary: "Courbd";
 
@@ -34,7 +34,7 @@ $spacing-unit: 30px !default;
 
 $text-color: #111 !default;
 $background-color: #fdfdfd !default;
-$brand-color: $brand-primary !default;
+$brand-color: $brand-color-primary !default;
 
 $grey-color: #828282 !default;
 $grey-color-light: lighten($grey-color, 40%) !default;

--- a/docs/_sass/_search-bar-base.scss
+++ b/docs/_sass/_search-bar-base.scss
@@ -1,0 +1,63 @@
+.search-bar {
+  .search-input {
+    margin: 0;
+    padding: $spacing-unit / 3;
+    color: inherit;
+    width: 175px;
+    border: 1px solid $grey-color;
+    border-radius: 0.4rem;
+    font-family: $base-font-family;
+
+    &:focus-visible {
+      outline-color: $brand-color;
+    }
+
+    &::placeholder {
+      color: $grey-color;
+    }
+  }
+
+  .results-container {
+    list-style: none;
+    margin: 0;
+    right: 0;
+    background-color: white;
+    border: 1px solid $grey-color-light;
+    border-radius: 0.4rem;
+    padding: $spacing-unit / 3;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  &--above {
+    position: relative;
+
+    .results-container {
+      position: absolute;
+      width: $on-palm;
+    }
+  }
+
+  &--align-right {
+    text-align: right;
+    right: 0;
+  }
+}
+
+@include media-query($on-palm) {
+  .search-bar {
+    .search-input {
+      width: calc(100% - (#{$spacing-unit} / 3) * 2);
+    }
+
+    .results-container {
+      width: inherit;
+    }
+
+    &--above {
+      text-align: left;
+    }
+  }
+}

--- a/docs/assets/css/styles.scss
+++ b/docs/assets/css/styles.scss
@@ -2,4 +2,5 @@
 ---
 
 @import "layout";
+@import "search-bar-base";
 @import "home";

--- a/docs/search.json
+++ b/docs/search.json
@@ -1,0 +1,14 @@
+---
+layout: none
+---
+[
+  {% for post in site.posts %}
+    {
+      "title"    : "{{ post.title | escape }}",
+      "category" : "{{ post.categories | join: ', '}}",
+      "tags"     : "{{ post.tags | join: ', ' }}",
+      "url"      : "{{ site.baseurl }}{{ post.url }}",
+      "date"     : "{{ post.date | date: site.minima.date_format }}"
+    } {% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]


### PR DESCRIPTION
#68 

Voici une proposition pour l’implémentation de la recherche sur le site
![search](https://user-images.githubusercontent.com/7658097/161841631-3e1bd0af-6382-4da0-b7e1-cb1fb2255e73.gif)


## Critères de recherche

La recherche s’effectue selon les critères défini dans le fichier `docs/search.json` i.e :

- Les titres des posts
- Les categories des posts
- Les tags des posts
- L’url des posts
- La date des posts


Ce que l’on pourrait ajouter :

- Le contenu des posts
- Le titre des pages
- Les catégories des pages
- Les tags des pages
- L’url des pages
- La date des pages
- Le contenu des pages

J’ai l’impression que les filtres utilisés actuellement sont suffisant, mais n’hésitez pas à me dire si il faut ajouter d’autres critères sur lesquelles filtrer.


## Implémentation de la barre de recherche

La barre de recherche a été implémenté de sorte que l'on puisse facilement l'utiliser via un include `{% include search_bar.html class="search-bar--above search-bar--align-right" %}`
Elle est customisable de via le paramètre `class` fourni lors de l’include, en effet :
il est possible d’overider la search bar de base de sorte que le contenu s’affiche au dessus du contenu présent en dessous en mettant la class `search-bar—-above`
il est possible d’aligner le contenu a droite en mettant la class `search-bar--align-right`

## Bonus

- Les 2 variables concernant les couleurs de la charte ont été renommer de sorte que ce soit plus lisible :
```sass
	$brand-color-primary: #e6223d; // anciennement $brand-primary 
	$brand-color-secondary: #1d1d1b; // anciennement $brand-secondary 
```

- Les éléments de paginations sont un peu plus sexy
![image](https://user-images.githubusercontent.com/7658097/161841208-b0cdc6d9-4173-4031-bad7-6591cc079f3c.png)

