### PR TITLE
suppression de l'email direct our éviter le spam

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,6 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Duchess France
-email: duchessfr@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Créée en 2010, Duchess France est une association destinée à valoriser et promouvoir les développeuses et les femmes avec des profils technique, leur donner plus de visibilité, mais aussi à faire connaître ces métiers technique et créer de nouvelles vocations.
 baseurl: "" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
Dans les autres pages du site on utilise duchessfr at gmail.com